### PR TITLE
[FIX] edoc: retorno pattern soap or env

### DIFF
--- a/nfelib/nfe/ws/edoc_legacy.py
+++ b/nfelib/nfe/ws/edoc_legacy.py
@@ -37,7 +37,10 @@ from xsdata.formats.dataclass.serializers.config import SerializerConfig
 
 def analisar_retorno_raw_xsdata(operacao, raiz, xml, retorno, classe):
     retorno.raise_for_status()
-    match = re.search("<soap:Body>(.*?)</soap:Body>", retorno.text.replace("\n", ""))
+    # Pattern to grab <soap:Body ... > OR <env:Body ... >
+    # The prefix (soap or env) varies depending on the UF
+    pattern = r"<(?:env|soap):Body[^>]*>(.*?)</(?:env|soap):Body>"
+    match = re.search(pattern, retorno.text.replace("\n", ""))
     if match:
         xml_resposta = match.group(1)
         # pega a resposta de dentro do envelope


### PR DESCRIPTION
## Objetivo

Corrigir a interpretação do retorno da obtenção de status no estado do Paraná e, possivelmente, na Bahia.

## Estados testasdos

Realizei testes na operação de obtenção do status do documento:

✅ **Mantém compatibilidade** com SC (42):
![image](https://github.com/user-attachments/assets/afcb5a42-51ed-4f7b-93cd-6f170182aada)

✅ **Adiciona compatibilidade** com PR (41):
![image](https://github.com/user-attachments/assets/5cfa6438-e407-4e66-bcc3-e22baf4be99e)



